### PR TITLE
Amend importing payment data

### DIFF
--- a/magefix/src/Magefix/Fixture/Builder/SalesOrder.php
+++ b/magefix/src/Magefix/Fixture/Builder/SalesOrder.php
@@ -184,7 +184,7 @@ class SalesOrder extends AbstractBuilder
 
     protected function _importPaymentData(array $data)
     {
-        $this->_getMageModel()->getPayment()->importData(['method' => $data['method']]);
+        $this->_getMageModel()->getPayment()->importData($data);
     }
 
     /**


### PR DESCRIPTION
For example when the payment method is credit card, the method parameter is not enough, because the selected card type should be passed to Magento as well.
This change makes sure that all payment related data is handed over to Magento.
