### PR TITLE
Patch 2

### DIFF
--- a/magefix/src/Magefix/Fixture/Builder/SalesOrder.php
+++ b/magefix/src/Magefix/Fixture/Builder/SalesOrder.php
@@ -42,8 +42,8 @@ class SalesOrder extends AbstractBuilder
         $this->_getMageModel()->setData($mergedData);
         $this->_buildQuoteProductFixtures();
         $this->_addProductsToQuote();
-        $this->_setCheckoutMethod();
         $this->_addAddressesToQuote();
+        $this->_setCheckoutMethod();
         $this->_setShippingMethod();
         $this->_setPaymentMethod();
 


### PR DESCRIPTION
In case of guest checkout there is no customer entity in database, so properties like email address have to be filled in.
`_setCheckoutMethod()` copes the email address from the billing address, but it's empty, because it will be filled out later in the `_addAddressesToQuote()` method.
I swapped these two methods to get the email address filled in. 
But it might break something else. Please check it.
